### PR TITLE
qml: Use first cmdline argument without -- prefix as configuration file name

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -22,8 +22,9 @@ Window {
 
     Component.onCompleted: {
         var xhr = new XMLHttpRequest();
-
-        xhr.open("GET", "file:" + (Qt.application.arguments[1] || "settings.json"));
+        let conf = "file:" + (Qt.application.arguments.slice(1).find(arg => !arg.startsWith("--")) || "settings.json");
+        console.log("Loading configuration from '" + conf + "'");
+        xhr.open("GET", conf);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 if (xhr.responseText.trim().length != 0) {


### PR DESCRIPTION
This is a simple fix to allow user to pass command line arguments to chromium itself, and still be able to load custom configuration file.