### PR TITLE
Feature/prevent vkb overlaying

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -36,7 +36,7 @@ Window {
             id: webView
             backgroundColor: "black"
 
-            url: ""http://www.ossystems.com.br"
+            url: "http://www.ossystems.com.br"
 
             anchors.fill: parent
             visible: false


### PR DESCRIPTION
This prevents input fields being at the bottom of a webpage from being hidden when the virtual keyboard input panel is shown.
