### PR TITLE
Update Project to Qt 6

### DIFF
--- a/browser.pro
+++ b/browser.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 
-QT += qml quick core gui webengine webenginewidgets
+QT += qml quick core gui webenginequick widgets
 
 CONFIG += c++11
 

--- a/main.cpp
+++ b/main.cpp
@@ -6,20 +6,26 @@
  * SPDX-License-Identifier:     GPL-3.0
  */
 
-#include <QApplication>
-#include <QtWebEngine>
+
+#include <QtQml/qqml.h>
+#include <QtWebEngineQuick/qtwebenginequickglobal.h>
+#include <QtQml/QQmlApplicationEngine>
+#include <QtQml/QQmlContext>
+#include <QtGui/QGuiApplication>
 
 #include "inputeventhandler.hpp"
 #include "browser.hpp"
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setApplicationName("QT kiosk browser");
+
     qputenv("QT_IM_MODULE", QByteArray("qtvirtualkeyboard"));
+    qputenv("QML_XHR_ALLOW_FILE_READ", QByteArray("1"));
+    
+    QtWebEngineQuick::initialize();
 
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
-
-    QtWebEngine::initialize();
 
     qmlRegisterSingletonType<InputEventHandler>("Browser", 1, 0, "Browser", [](QQmlEngine *, QJSEngine *) -> QObject * {
         return new Browser();

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -6,17 +6,19 @@
  * SPDX-License-Identifier:     GPL-3.0
  */
 
-import QtQuick 2.0
-import QtQuick.Window 2.1
-import QtWebEngine 1.4
-import QtQuick.VirtualKeyboard 2.1
+import QtQuick 2.15
+import QtQuick.Window 2.15
+
+import QtWebEngine 1.7
+import QtQuick.VirtualKeyboard 2.2
+import QtQuick.VirtualKeyboard.Settings 2.2
 
 import Browser 1.0
 
 Window {
     id: window
+    visibility: "FullScreen"
 
-    visibility: Window.FullScreen
     visible: true
     color: "black"
   
@@ -43,8 +45,8 @@ Window {
 
             property bool disableContextMenu: false
 
-            onLoadingChanged: {
-                if (loadRequest.status === WebEngineLoadRequest.LoadSucceededStatus) {
+            onLoadingChanged: function(loadRequest) {
+                if (loadRequest.status == WebEngineView.LoadSucceededStatus) {
                     webView.visible = true;
                     splash.visible = false;
                 }


### PR DESCRIPTION
This PR updates the project from Qt 5 to Qt 6. The changes made include:

1. **browser.pro**: Updated the Qt modules used in the project. The following changes were made:
   - Removed: `webengine` and `webenginewidgets`
   - Added: `webenginequick` and `widgets`

2. **main.cpp**: Adjusted the Qt includes and initialization for Qt 6. The following changes were made:
   - Updated includes to use Qt 6 headers.
   - Added application name with `QCoreApplication::setApplicationName`.
   - Set environment variables `QT_IM_MODULE` and `QML_XHR_ALLOW_FILE_READ`.
   - Initialized QtWebEngineQuick with `QtWebEngineQuick::initialize`.

These changes ensure compatibility with Qt 6 and update the project accordingly.