### PR TITLE
browser: Add proxy support using environment variables

### DIFF
--- a/browser.pro
+++ b/browser.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 
-QT += qml quick core gui webengine webenginewidgets
+QT += qml quick core gui webengine webenginewidgets network
 
 CONFIG += c++11
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 
 #include <QApplication>
 #include <QtWebEngine>
+#include <QNetworkProxyFactory>
 
 #include "inputeventhandler.hpp"
 #include "browser.hpp"
@@ -18,6 +19,8 @@ int main(int argc, char *argv[])
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
+
+    QNetworkProxyFactory::setUseSystemConfiguration(true);
 
     QtWebEngine::initialize();
 


### PR DESCRIPTION
Updated project to support proxy settings based on `https_proxy` and `http_proxy` environment variables. Modified `browser.pro` to include the QT `network` module and altered `main.cpp` to utilize `QNetworkProxyFactory`, enabling the application to automatically adhere to system proxy configurations.