### PR TITLE
browser: Add proxy support using environment variables

### DIFF
--- a/browser.pro
+++ b/browser.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 
-QT += qml quick core gui webenginequick widgets
+QT += qml quick core gui webenginequick widgets network
 
 CONFIG += c++11
 

--- a/main.cpp
+++ b/main.cpp
@@ -12,6 +12,7 @@
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>
 #include <QtGui/QGuiApplication>
+#include <QNetworkProxyFactory>
 
 #include "inputeventhandler.hpp"
 #include "browser.hpp"
@@ -22,6 +23,8 @@ int main(int argc, char *argv[])
 
     qputenv("QT_IM_MODULE", QByteArray("qtvirtualkeyboard"));
     qputenv("QML_XHR_ALLOW_FILE_READ", QByteArray("1"));
+
+    QNetworkProxyFactory::setUseSystemConfiguration(true);
     
     QtWebEngineQuick::initialize();
 


### PR DESCRIPTION
Updated project to support proxy settings based on `https_proxy` and `http_proxy` environment variables. Modified `browser.pro` to include the QT `network` module and altered `main.cpp` to utilize `QNetworkProxyFactory`, enabling the application to automatically adhere to system proxy configurations.